### PR TITLE
Fixes for Firefox Android

### DIFF
--- a/background.js
+++ b/background.js
@@ -103,7 +103,7 @@ Page Translator functionality
 
 function injectTranslatorCode() {
     let googleCode = `
-        let docBody = document.body;
+        var docBody = document.body;
 
         if (docBody !== null) {
             let googleTranslateCallback = document.createElement('script');
@@ -122,7 +122,7 @@ function injectTranslatorCode() {
     `;
 
     let microsoftCode = `
-        let docBody = document.body;
+        var docBody = document.body;
 
         if (docBody !== null) {
             let div = '<div id="MicrosoftTranslatorWidget" class="Dark" style="color:white;background-color:#555555"></div>';

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
         "128": "icons/icon-128.png"
     },
     "permissions": [
+        "<all_urls>",
         "activeTab",
         "storage",
         "tabs"


### PR DESCRIPTION
I've made the following changes to make this extension work on Android:
- Request for 'all urls' permissions to allow script injection in any page
- Use 'var' instead of 'let' to prevent a redefinition error when the action is re-invoked (there may be a more elegant way of doing this)

There's an additional problem in Firefox for Android 54, which is that the icon shown is too small. This seems to be a bug in Firefox since it does not occur in the beta or nightly versions. (I tried declaring the png versions instead but that didn't help.)